### PR TITLE
Feat i18n support

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -1,9 +1,21 @@
 
-import express, { NextFunction, Response } from 'express'
+import express, { NextFunction, Response, Request } from 'express'
 import throwlhos, { IThrowlhos } from './index'
 import errorHandler from 'responserror'
 import request from 'supertest'
 import responser from 'responser'
+
+const i18nKeys: Record<string, string> = {
+  'error.custom': 'This is a custom error! - I was translated'
+}
+
+const translationMiddleware = (error: any, _request: Request, _response: Response, next: NextFunction): void => {
+  if(error.i18n) {
+    error.message = i18nKeys[error.i18n.key]
+    delete error.i18n
+  }
+  next(error)
+}
 
 test('it returns correctly formated object (object)', async () => {
   const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Sorry, something is missing!', {
@@ -173,6 +185,113 @@ test('it can throw custom errors', async () => {
     code: 500,
     status: 'CUSTOM_ERROR',
     message: 'This is a custom error!',
+    success: false,
+    errors: {
+      fruit: 'banana'
+    }
+  })
+})
+
+test('it accepts i18n object without i18n.options', async () => {
+  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found', undefined, { key: 'error.not_found' })
+  expect(notFoundThrowlhos).toEqual({
+    message: 'Not Found',
+    code: 404,
+    status: 'NOT_FOUND',
+    i18n: { key: 'error.not_found' }
+  })
+})
+
+test('it accepts i18n object with i18n.options', async () => {
+  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found', { }, { key: 'error.not_found', options: { resource: 'item' } })
+  expect(notFoundThrowlhos).toEqual({
+    message: 'Not Found',
+    code: 404,
+    status: 'NOT_FOUND',
+    i18n: { key: 'error.not_found', options: { resource: 'item' } }
+  })
+})
+
+test('it can throw errors with i18n object in output', async () => {
+  const app = express()
+  app.use(responser)
+  app.use(throwlhos.middleware)
+  const router = express.Router()
+  router.post('/resources', (_, response: Response, next: NextFunction) => {
+    try {
+      const randomObject = { fruit: 'banana' }
+      throw response.err_badRequest('This is a bad request with i18n!', randomObject, { key: 'error.badRequest', options: { item: 'banana' } })
+    } catch(err) {
+      return next(err)
+    }
+  })
+ 
+  /* @ts-ignore */
+  app.use(router, errorHandler)
+  const response = await request(app).post('/resources')
+  expect(response.body).toEqual({
+    code: 400,
+    status: 'BAD_REQUEST',
+    message: 'This is a bad request with i18n!',
+    success: false,
+    errors: {
+      fruit: 'banana'
+    },
+    i18n: { key: 'error.badRequest', options: { item: 'banana' } }
+  })
+})
+
+test('it can throw custom errors with i18n object in output', async () => {
+  const app = express()
+  app.use(responser)
+  app.use(throwlhos.middleware)
+  const router = express.Router()
+  router.post('/resources', (_, response: Response, next: NextFunction) => {
+    try {
+      const randomObject = { fruit: 'banana' }
+      throw response.err_custom('This is a custom error with i18n!', 500, randomObject, { key: 'error.custom', options: { item: 'banana' } })
+    } catch(err) {
+      return next(err)
+    }
+  })
+ 
+  /* @ts-ignore */
+  app.use(router, errorHandler)
+  const response = await request(app).post('/resources')
+  expect(response.body).toEqual({
+    code: 500,
+    status: 'CUSTOM_ERROR',
+    message: 'This is a custom error with i18n!',
+    success: false,
+    errors: {
+      fruit: 'banana'
+    },
+    i18n: { key: 'error.custom', options: { item: 'banana' } }
+  })
+})
+
+test('it can be used with a translator middleware for override message', async () => {
+  const app = express()
+  app.use(responser)
+  app.use(throwlhos.middleware)
+  const router = express.Router()
+  router.post('/resources', (_, response: Response, next: NextFunction) => {
+    try {
+      const randomObject = { fruit: 'banana' }
+      throw response.err_custom('This is a custom error!', 500, randomObject, { key: 'error.custom' })
+    } catch(err) {
+      return next(err)
+    }
+  })
+  
+  // Simulating a translation middleware that overrides the message based on i18n object
+  app.use(router, translationMiddleware)
+  app.use(router, errorHandler)
+  const response = await request(app).post('/resources')
+  expect(response.body).toEqual({
+    code: 500,
+    status: 'CUSTOM_ERROR',
+    message: 'This is a custom error! - I was translated',
     success: false,
     errors: {
       fruit: 'banana'

--- a/index.test.ts
+++ b/index.test.ts
@@ -192,23 +192,33 @@ test('it can throw custom errors', async () => {
   })
 })
 
-test('it accepts i18n object without i18n.options', async () => {
-  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found', undefined, { key: 'error.not_found' })
+test('it accepts i18n object without i18n.options using err_*', async () => {
+  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found without i18n.options', undefined, { key: 'error.not_found' })
   expect(notFoundThrowlhos).toEqual({
-    message: 'Not Found',
+    message: 'Not Found without i18n.options',
     code: 404,
     status: 'NOT_FOUND',
     i18n: { key: 'error.not_found' }
   })
 })
 
-test('it accepts i18n object with i18n.options', async () => {
-  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found', { }, { key: 'error.not_found', options: { resource: 'item' } })
+test('it accepts i18n object with i18n.options using err_*', async () => {
+  const notFoundThrowlhos: IThrowlhos = throwlhos.err_notFound('Not Found with i18n.options', { }, { key: 'error.not_found', options: { resource: 'item' } })
   expect(notFoundThrowlhos).toEqual({
-    message: 'Not Found',
+    message: 'Not Found with i18n.options',
     code: 404,
     status: 'NOT_FOUND',
     i18n: { key: 'error.not_found', options: { resource: 'item' } }
+  })
+})
+
+test('it accepts i18n object using err_custom', async () => {
+  const customThrowlhos: IThrowlhos = throwlhos.err_custom('Custom error with i18n', 404, { }, { key: 'error.custom', options: { resource: 'item' } })
+  expect(customThrowlhos).toEqual({
+    message: 'Custom error with i18n',
+    code: 404,
+    status: 'CUSTOM_ERROR',
+    i18n: { key: 'error.custom', options: { resource: 'item' } }
   })
 })
 


### PR DESCRIPTION
## Adding internationalization property on Throwlhos

This pull request adds support for internationalization (i18n) to this library, allowing error responses to include translation keys and options for easier integration with translation systems. The documentation and tests have been updated to demonstrate and verify the new i18n functionality.

🌐 **i18n support for error responses:**

* The error methods (`err_*` and `err_custom`) now accept an optional third `i18n` parameter, which can include a translation key and options for message interpolation. The resulting error object includes the `i18n` property if provided
* The `IThrowlhos` type and related TypeScript definitions have been updated to include the optional `i18n` property. 

### 📖 **Documentation:**

* The `README.md` now documents the new `i18n` parameter, explains its usage, and provides examples of integrating with translation middleware (such as i18next).

### 🧪  **Testing:**

Added 6 new tests to `index.test.ts` to verify i18n behavior
* Usage with err_* as third parameter without i18n.options
* Usage with err_* as third parameter with i18n.options
* Usage with err_custom as fourth parameter with i18n.options
* Throwing err_* with i18n object
* Throwing err_custom with i18n object
* Usage with a simulation of a translation middleware (recomended use)

### 📊  **Coverage results (no breaking changes):**
<img width="515" height="198" alt="image" src="https://github.com/user-attachments/assets/7063129c-e0cb-4d3c-a73c-baebdca33809" />
